### PR TITLE
Make the Docker images produced support `arm64`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,6 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ github.repository }}:latest


### PR DESCRIPTION
Make the Docker images produced support the `arm64` platform.